### PR TITLE
[cache] #45109 add stale while revalidate cache header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add the `litespeed_finish_request` method to work with Litespeed
  * Deprecate `upload_progress.*` and `url_rewriter.tags` session options
  * Allow setting session options via DSN
+ * Add cache header stale-while-revalidate and stale-if-error RFC5861 support
 
 5.3
 ---

--- a/Response.php
+++ b/Response.php
@@ -98,6 +98,8 @@ class Response
         'proxy_revalidate' => false,
         'max_age' => true,
         's_maxage' => true,
+        'stale_if_error' => true,         // RFC5861
+        'stale_while_revalidate' => true, // RFC5861
         'immutable' => false,
         'last_modified' => true,
         'etag' => true,
@@ -796,6 +798,39 @@ class Response
         return $this;
     }
 
+
+    /**
+     * Sets the number of seconds after which the response should no longer be returned by shared caches when backend is down.
+     *
+     * This methods sets the Cache-Control stale-if-error directive.
+     *
+     * @return $this
+     *
+     * @final
+     */
+    public function setStaleIfError(int $value): object
+    {
+        $this->headers->addCacheControlDirective('stale-if-error', $value);
+
+        return $this;
+    }
+
+    /**
+     * Sets the number of seconds after which the response should no longer return stale content by shared caches.
+     *
+     * This methods sets the Cache-Control stale-while-revalidate directive.
+     *
+     * @return $this
+     *
+     * @final
+     */
+    public function setStaleWhileRevalidate(int $value): object
+    {
+        $this->headers->addCacheControlDirective('stale-while-revalidate', $value);
+
+        return $this;
+    }
+
     /**
      * Sets the number of seconds after which the response should no longer be considered fresh by shared caches.
      *
@@ -967,6 +1002,14 @@ class Response
 
         if (isset($options['s_maxage'])) {
             $this->setSharedMaxAge($options['s_maxage']);
+        }
+
+        if (isset($options['stale_while_revalidate'])) {
+            $this->setStaleWhileRevalidate($options['stale_while_revalidate']);
+        }
+
+        if (isset($options['stale_if_error'])) {
+            $this->setStaleIfError($options['stale_if_error']);
         }
 
         foreach (self::HTTP_RESPONSE_CACHE_CONTROL_DIRECTIVES as $directive => $hasValue) {

--- a/Tests/ResponseTest.php
+++ b/Tests/ResponseTest.php
@@ -356,6 +356,44 @@ class ResponseTest extends ResponseTestCase
         $this->assertEquals('public, s-maxage=20', $cacheControl);
     }
 
+    public function testSetStaleIfError()
+    {
+        $response = new Response();
+        $response->setSharedMaxAge(20);
+        $response->setStaleIfError(86400);
+
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertEquals('public, s-maxage=20, stale-if-error=86400', $cacheControl);
+    }
+
+    public function testSetStaleWhileRevalidate()
+    {
+        $response = new Response();
+        $response->setSharedMaxAge(20);
+        $response->setStaleWhileRevalidate(300);
+
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertEquals('public, s-maxage=20, stale-while-revalidate=300', $cacheControl);
+    }
+
+    public function testSetStaleIfErrorWithoutSharedMaxAge()
+    {
+        $response = new Response();
+        $response->setStaleIfError(86400);
+
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertEquals('stale-if-error=86400, private', $cacheControl);
+    }
+
+    public function testSetStaleWhileRevalidateWithoutSharedMaxAge()
+    {
+        $response = new Response();
+        $response->setStaleWhileRevalidate(300);
+
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertEquals('stale-while-revalidate=300, private', $cacheControl);
+    }
+
     public function testIsPrivate()
     {
         $response = new Response();


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->

Q | A
-- | --
Branch? | 5.4
Bug fix? | no
New feature? | yes
Deprecations? | no
Tickets | -
License | MIT
Doc PR | -

<!--EndFragment-->
</body>
</html>

This PR allow support for RFC5861.
Meaning you can now use stale_while_revalidate and stale_if_error
https://httpwg.org/specs/rfc5861.html

Very interesting doc from Fastly on the subject:
https://developer.fastly.com/learning/concepts/stale/